### PR TITLE
feat: publish workflow for cx contexts

### DIFF
--- a/.github/workflows/publish-context.yaml
+++ b/.github/workflows/publish-context.yaml
@@ -1,0 +1,46 @@
+#################################################################################
+#  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+
+---
+name: Publish JSON-LD context
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cx/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: copy contexts into public folder
+        run: |
+          mkdir -p public/cx/context
+          cp cx/credentials/schema/context/* public/cx/context/
+
+      - name: deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          keep_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 
 .DS_Store
 .env
+/public


### PR DESCRIPTION

## Description

This PR introduces a workflow for publishing JSON-LD context into the `gh-pages` branch 


- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
