### PR TITLE
Update claim

### DIFF
--- a/tx/refresh/refresh.token.grant.profile.md
+++ b/tx/refresh/refresh.token.grant.profile.md
@@ -102,7 +102,7 @@ following specifications:
   used to verify the JWT.
 - The `iss` claim is set to the client's `DID`.
 - The `sub` claim is set to the client's `DID`.
-- A `accessToken` contains the access token associated with the refresh token.
+- A `access_token` contains the access token associated with the refresh token.
 - The JWT is signed using the private key associated with the key material specified by the `kid` header parameter.
 
 ### 3.2. Provider Request Validation

--- a/tx/refresh/refresh.token.grant.profile.md
+++ b/tx/refresh/refresh.token.grant.profile.md
@@ -102,7 +102,7 @@ following specifications:
   used to verify the JWT.
 - The `iss` claim is set to the client's `DID`.
 - The `sub` claim is set to the client's `DID`.
-- A `refreshClaim` contains the refresh token.
+- A `accessToken` contains the access token associated with the refresh token.
 - The JWT is signed using the private key associated with the key material specified by the `kid` header parameter.
 
 ### 3.2. Provider Request Validation


### PR DESCRIPTION
Renames the `refreshClaim` and specifies the access token to be set as opposed to the refresh token. Avoids redundancy.

Closes #18 