### PR TITLE
Separate tractusx and catenax namespace

### DIFF
--- a/cx/credentials/specs/specification.changes.md
+++ b/cx/credentials/specs/specification.changes.md
@@ -6,3 +6,4 @@
 4. Create separate policy context using the URI: https://w3id.org/catenax/policy/v1.0.0
 5. Create JSON Schema definitions for all credentials using the URI: https://w3id.org/catenax/schemas/v1.0.0/
 6. Adopt JWT-based VCs using JWS algorithm `ES256K` and JWK curve `secp256k1`
+7. Separate namespaces for `tractusx` and `catenax`

--- a/cx/policy/samples/policy.sample.contract.reference.json
+++ b/cx/policy/samples/policy.sample.contract.reference.json
@@ -3,7 +3,7 @@
     {
       "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
     },
-    "https://w3id.org/catenax/policy/v1.0.0",
+    "https://w3id.org/tractusx/policy/v1.0.0",
     "http://www.w3.org/ns/odrl.jsonld"
   ],
   "@id": "definition-id",

--- a/cx/policy/samples/policy.sample.json
+++ b/cx/policy/samples/policy.sample.json
@@ -3,7 +3,7 @@
     {
       "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
     },
-    "https://w3id.org/catenax/policy/v1.0.0",
+    "https://w3id.org/tractusx/policy/v1.0.0",
     "http://www.w3.org/ns/odrl.jsonld"
   ],
   "@id": "definition-id",

--- a/cx/policy/samples/policy.sample.purpose.json
+++ b/cx/policy/samples/policy.sample.purpose.json
@@ -3,7 +3,7 @@
     {
       "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
     },
-    "https://w3id.org/catenax/policy/v1.0.0",
+    "https://w3id.org/tractusx/policy/v1.0.0",
     "http://www.w3.org/ns/odrl.jsonld"
   ],
   "@id": "definition-id",

--- a/cx/policy/specs/policy.definitions.md
+++ b/cx/policy/specs/policy.definitions.md
@@ -279,7 +279,7 @@ an active signed traceability agreement:
  {
   "@context": [
     "https://www.w3.org/ns/odrl.jsonld",
-    "https://w3id.org/catenax/policy/v1.0.0"
+    "https://w3id.org/tractusx/policy/v1.0.0"
   ],
   "@type": "Offer",
   "@id": "a343fcbf-99fc-4ce8-8e9b-148c97605aab",


### PR DESCRIPTION
@jimmarino could you have a look at this PR? It is what we agreed to separate the `tractusx` and `catenax` namepsaces, especially for referring to the jsonld context defined inside the repository here.