### PR TITLE
feat:  Include DataExchangeGovernanceCredential in credential.context

### DIFF
--- a/cx/credentials/schema/context/credentials.context.json
+++ b/cx/credentials/schema/context/credentials.context.json
@@ -5,6 +5,9 @@
     "cred": "https://www.w3.org/2018/credentials#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "cx-credentials": "https://w3id.org/catenax/credentials/",
+    "DataExchangeGovernanceCredential": {
+      "@id": "cx-credentials:DataExchangeGovernanceCredential"
+    },
     "BehavioralTwinCredential": {
       "@id": "cx-credentials:BehavioralTwinCredential"
     },


### PR DESCRIPTION
## Description
A new framework agreement called Data Exchanged Governance is introduced with Catena-X Release 2408. Thus, we need a new credential to verify the approval to this agreement. This credential need to be listed in this context.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
