### PR TITLE
chore(legal): Update legal documents according to TRG7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,33 +14,49 @@ where these companies will be able to participate quickly and with little IT
 infrastructure investment. Tractus-X is meant to be the PoC project of the
 Catena-X alliance focusing on parts traceability.
 
-* <https://projects.eclipse.org/projects/automotive.tractusx>
+* https://projects.eclipse.org/projects/automotive.tractusx
+
+## Project licenses
+
+This Tractus-X project repository uses the following license:
+
+* Apache-2.0
+
+## Terms of Use
+
+This repository is subject to the Terms of Use of the Eclipse Foundation
+
+* https://www.eclipse.org/legal/termsofuse.php
 
 ## Developer resources
 
 Information regarding source code management, builds, coding standards, and
 more.
 
-* <https://projects.eclipse.org/projects/automotive.tractusx/developer>
+* https://projects.eclipse.org/projects/automotive.tractusx/developer
+
+Getting started:
+
+* https://eclipse-tractusx.github.io/docs/developer
 
 The project maintains the source code repositories in the following GitHub organization:
 
-* <https://github.com/eclipse-tractusx/>
+* https://github.com/eclipse-tractusx
 
 ## Eclipse Development Process
 
 This Eclipse Foundation open project is governed by the Eclipse Foundation
 Development Process and operates under the terms of the Eclipse IP Policy.
 
-* <https://eclipse.org/projects/dev_process>
-* <https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf>
+* https://eclipse.org/projects/dev_process
+* https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf
 
 ## Eclipse Contributor Agreement
 
 In order to be able to contribute to Eclipse Foundation projects you must
 electronically sign the Eclipse Contributor Agreement (ECA).
 
-* <http://www.eclipse.org/legal/ECA.php>
+* http://www.eclipse.org/legal/ECA.php
 
 The ECA provides the Eclipse Foundation with a permanent record that you agree
 that each of your contributions will comply with the commitments documented in
@@ -49,10 +65,10 @@ the email address matching the "Author" field of your contribution's Git commits
 fulfills the DCO's requirement that you sign-off on your contributions.
 
 For more information, please see the Eclipse Committer Handbook:
-<https://www.eclipse.org/projects/handbook/#resources-commit>
+https://www.eclipse.org/projects/handbook/#resources-commit
 
 ## Contact
 
 Contact the project developers via the project's "dev" list.
 
-* <https://accounts.eclipse.org/mailing-list/tractusx-dev>
+* https://accounts.eclipse.org/mailing-list/tractusx-dev

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,7 +2,7 @@
 
 This content is produced and maintained by the Eclipse Tractus-X project.
 
-* Project home: <https://projects.eclipse.org/projects/automotive.tractusx>
+* Project home: https://projects.eclipse.org/projects/automotive.tractusx
 
 See the AUTHORS file(s) distributed with this work for additional information regarding authorship.
 
@@ -18,18 +18,20 @@ source code repository logs.
 
 ## Declared Project Licenses
 
-This program and the accompanying materials are made available under the terms
-of the Apache License, Version 2.0 which is available at
-<https://www.apache.org/licenses/LICENSE-2.0>.
+This Tractus-X project repository uses the following license:
+
+* Apache-2.0
+
+This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0 which is available at https://www.apache.org/licenses/LICENSE-2.0.
 
 SPDX-License-Identifier: Apache-2.0
 
 ## Source Code
 
 The project maintains the following source code repositories
-in the GitHub organization <https://github.com/eclipse-tractusx>:
+in the GitHub organization https://github.com/eclipse-tractusx:
 
-* <https://github.com/eclipse-tractusx/tractusx-profiles>
+* https://github.com/eclipse-tractusx/tractusx-profiles
 
 ## Third-party Content
 


### PR DESCRIPTION
## Description

Update the notice and contributing file according to the prerequisites of TRG 7. Note, that the only project license remains Apache-2.0 for two reasons:
- Separation of code and non-code is difficult in this repository
- The existing content is already licensed as Apache-2.0, so a license change is not required.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files

Closes #32 
