### PR TITLE
docs: EDR token refresh implementation is inconsistent and deviates from the documentation

### DIFF
--- a/tx/refresh/refresh.token.grant.profile.md
+++ b/tx/refresh/refresh.token.grant.profile.md
@@ -85,12 +85,10 @@ The client sends refresh token requests to the provider's data plane authorizati
 2 `refresh_token` grant type. A non-normative example is as follows:
 
 ```
-POST /token HTTP/1.1
+POST /token?grant_type=refresh_token&refresh_token=dFds4UOlH1QP7Fj3OkOAxM HTTP/1.1
 Host: server.example.com
 Content-Type: application/x-www-form-urlencoded
 Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
-
-grant_type=refresh_token&refresh_token=dFds4UOlH1QP7Fj3OkOAxM
 ```
 
 ### 3.1. Client Authentication


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Change the refresh token documentation according to the implementation
<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Fixes [1565](https://github.com/eclipse-tractusx/tractusx-edc/issues/1565)
## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
