### PR TITLE
chore: added new credential context from data trust & security kit

### DIFF
--- a/tx/credentials/schema/context/DataAttestationCredential.json-ld
+++ b/tx/credentials/schema/context/DataAttestationCredential.json-ld
@@ -1,0 +1,85 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "schema": "https://schema.org/",
+    "aspect": "https://github.com/eclipse-tractusx/tractusx-profiles/blob/main/cx/credentials/schema/context/DataAttestationCredential.json-ld#",
+    "DataAttestationCredential": {
+      "@context": {
+        "@version": 1.1,
+        "id": "@id",
+        "type": "@type",
+        "validationMethod": {
+          "@id": "aspect:validationMethod",
+          "@context": {
+            "@version": 1.1,
+            "id": "@id",
+            "type": "@type",
+            "@context": {
+              "@version": 1.1,
+              "id": {
+                "@id": "aspect:id",
+                "@context": {
+                  "@definition": "Mandatory: Unique identifier for the validation method."
+                },
+                "@type": "schema:string"
+              },
+              "type": {
+                "@id": "aspect:type",
+                "@context": {
+                  "@definition": "Mandatory: The type of validation method used for data attestation."
+                },
+                "@type": "schema:string"
+              },
+              "label": {
+                "@id": "aspect:label",
+                "@context": {
+                  "@definition": "Mandatory: Human-readable label for the validation method."
+                },
+                "@type": "schema:string"
+              },
+              "uri": {
+                "@id": "aspect:uri",
+                "@context": {
+                  "@definition": "Mandatory: URI pointing to the validation method documentation or specification."
+                },
+                "@type": "schema:string"
+              },
+              "complianceCriteria": {
+                "@id": "aspect:complianceCriteria",
+                "@context": {
+                  "@version": 1.1,
+                  "id": "@id",
+                  "type": "@type",
+                  "@context": {
+                    "@version": 1.1,
+                    "id": "@id",
+                    "type": {
+                      "@id": "aspect:type",
+                      "@context": {
+                        "@definition": "Mandatory: The type of compliance criterion used for validation."
+                      },
+                      "@type": "schema:string"
+                    },
+                    "value": {
+                      "@id": "aspect:value",
+                      "@context": {
+                        "@definition": "Mandatory: The value of the compliance criterion."
+                      },
+                      "@type": "schema:string"
+                    }
+                  },
+                  "@definition": "Mandatory: Set of compliance criteria for the validation method."
+                },
+                "@container": "@list"
+              }
+            },
+            "@definition": "Array of validation methods used for data verification and attestation in Data Attestation Credential (DAC)."
+          },
+          "@container": "@list"
+        },
+        "@definition": "A Data Attestation Credential (DAC) represents validation methods and compliance criteria used for data verification and attestation"
+      },
+      "@id": "aspect:DataAttestationCredential"
+    }
+  }
+}


### PR DESCRIPTION

## Description

In order to enable verifiable credentials for products in Tractus-X we need to keep the context from the credentials public.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
